### PR TITLE
xcop.rb: Removes \n at the end of the corrected output

### DIFF
--- a/lib/xcop.rb
+++ b/lib/xcop.rb
@@ -106,16 +106,14 @@ module Xcop
 
     def differ(ideal, fact, nocolor = false)
       return '' if ideal == fact
-      if nocolor
-        Differ.diff_by_line(ideal, fact).to_s
-      else
+      unless nocolor
         Differ.format = :color
-        Differ.diff_by_line(schars(ideal), schars(fact)).to_s
       end
+      Differ.diff_by_line(schars(ideal), schars(fact)).to_s
     end
 
     def schars(text)
-      text.gsub(/\n/, "\\n\n")
+      text.gsub(/\n/, "\n")
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/yegor256/xcop/issues/25

Many thanks for your contribution, we truly appreciate it. We will appreciate it even more, if you make sure that you can say "YES" to each point in this short checklist:

  - You made a small amount of changes (less than 100 lines, less than 10 files)
  - You made changes related to only one bug (create separate PRs for separate problems)
  - You are ready to defend your changes (there will be a code review)
  - You don't touch what you don't understand
  - You ran the build locally and it passed

This article will help you understand what we are looking for: http://www.yegor256.com/2015/02/09/serious-code-reviewer.html

Thank you for your contribution!
