### PR TITLE
Unable to use xcop with ruby 2.7.1 due to obsolete nokogiri dependency

### DIFF
--- a/xcop.gemspec
+++ b/xcop.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'LICENSE.txt']
   s.add_runtime_dependency 'differ', '~>0.1.2'
-  s.add_runtime_dependency 'nokogiri', '~>1.8'
+  s.add_runtime_dependency 'nokogiri', '~>1.10.9'
   s.add_runtime_dependency 'rainbow', '~>3.0'
   s.add_runtime_dependency 'slop', '~>4.4'
   s.add_development_dependency 'codecov', '0.1.10'
@@ -53,7 +53,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '5.5.0'
   s.add_development_dependency 'rake', '12.0.0'
   s.add_development_dependency 'rdoc', '4.2.0'
-  s.add_development_dependency 'rspec-rails', '3.1.0'
   s.add_development_dependency 'rubocop', '0.52.0'
   s.add_development_dependency 'rubocop-rspec', '1.5.1'
 end


### PR DESCRIPTION
https://github.com/sparklemotion/nokogiri/issues/1961
```bash
...
Fetching nokogiri 1.10.9 (x64-mingw32)
Installing nokogiri 1.10.9 (x64-mingw32)
Gem::RuntimeRequirementNotMetError: nokogiri requires Ruby version >= 2.3, <
2.7.dev. The current ruby version is 2.7.1.83.
An error occurred while installing nokogiri (1.10.9), and Bundler cannot
continue.
Make sure that `gem install nokogiri -v '1.10.9' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  xcop was resolved to 0.6, which depends on
    nokogiri

```