### PR TITLE
#55: Accept a directory as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ can ask it to "beautify" them using the `--fix` option:
 xcop --fix broken-file.xml
 ```
 
-To fix all files in a directory, you can do the following
-([this won't work](https://askubuntu.com/questions/343727/) if your file
-names contain spaces):
+You can also pass a directory as an argument. In that case `xcop` will
+recursively find every `.xml`, `.xsd`, `.xhtml`, `.xsl`, and `.html`
+file inside it:
 
 ```bash
-xcop --fix $(find . -name '*.xml')
+xcop .
+xcop --fix src/resources
 ```
 
 ## Defaults

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -43,3 +43,21 @@ Feature: Command Line Processing
     Then Exit code is zero
     Then I run bin/xcop with "broken.xml"
     Then Exit code is zero
+
+  Scenario: Validating a directory of XML files recursively
+    Given I have a "pkg/top.xml" file with content:
+    """
+    <?xml version="1.0"?>
+    <hello>Hello, world!</hello>
+
+    """
+    And I have a "pkg/nested/deep.xsl" file with content:
+    """
+    <?xml version="1.0"?>
+    <hello>Hello, world!</hello>
+
+    """
+    When I run bin/xcop with "pkg"
+    Then Stdout contains "top.xml looks good"
+    And Stdout contains "deep.xsl looks good"
+    And Exit code is zero

--- a/lib/xcop/cli.rb
+++ b/lib/xcop/cli.rb
@@ -12,9 +12,17 @@ require_relative 'document'
 # Copyright:: Copyright (c) 2017-2026 Yegor Bugayenko
 # License:: MIT
 class Xcop::CLI
+  # Extensions recognized when a directory is passed as input.
+  EXTENSIONS = %w[xml xsd xhtml xsl html].freeze
+
   def initialize(files, nocolor: false)
-    @files = files
+    @files = files.flat_map { |f| File.directory?(f) ? Xcop::CLI.expand(f) : [f] }
     @nocolor = nocolor
+  end
+
+  # Recursively collect XML-like files inside a directory.
+  def self.expand(dir)
+    EXTENSIONS.flat_map { |ext| Dir.glob(File.join(dir, '**', "*.#{ext}")) }.sort
   end
 
   def run

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'fileutils'
 require 'minitest/autorun'
 require 'tmpdir'
 require_relative '../lib/xcop/cli'
@@ -133,6 +134,47 @@ class CLITest < Minitest::Test
         original_content,
         File.read(f),
         "Expected to fix invalid file - '#{f}'"
+      )
+    end
+  end
+
+  def test_run_on_directory_processes_xml_files_recursively
+    Dir.mktmpdir 'test_dir_input' do |dir|
+      nested = File.join(dir, 'nested')
+      FileUtils.mkdir_p(nested)
+      f1 = File.join(dir, 'top.xml')
+      f2 = File.join(nested, 'deep.xsl')
+      File.write(f1, "<?xml version=\"1.0\"?>\n<root>\n  <item>1</item>\n</root>\n")
+      File.write(f2, "<?xml version=\"1.0\"?>\n<root>\n  <item>2</item>\n</root>\n")
+      processed = []
+      cli = Xcop::CLI.new([dir])
+      cli.run { |file| processed << file }
+      assert_includes(
+        processed,
+        f1,
+        "Expected to include '#{f1}' when directory '#{dir}' is given"
+      )
+      assert_includes(
+        processed,
+        f2,
+        "Expected to include '#{f2}' when directory '#{dir}' is given"
+      )
+    end
+  end
+
+  def test_run_on_directory_ignores_non_xml_files
+    Dir.mktmpdir 'test_dir_skip' do |dir|
+      xml = File.join(dir, 'good.xml')
+      txt = File.join(dir, 'notes.txt')
+      File.write(xml, "<?xml version=\"1.0\"?>\n<root>\n  <item>1</item>\n</root>\n")
+      File.write(txt, 'not xml')
+      processed = []
+      cli = Xcop::CLI.new([dir])
+      cli.run { |file| processed << file }
+      assert_equal(
+        [xml],
+        processed,
+        "Expected only '#{xml}' to be processed, got '#{processed}'"
       )
     end
   end


### PR DESCRIPTION
@yegor256 this PR closes #55 — passing a directory to `xcop` now works instead of crashing.

## What was broken

```bash
$ xcop ./src
Is a directory @ io_fillbuf - fd:5 ./src
```

`Xcop::CLI` fed every argument straight into `Xcop::Document.new`, which opened it as a file. Directories raised `Errno::EISDIR`.

## What this PR does

- `lib/xcop/cli.rb`: `Xcop::CLI#initialize` now flat-maps its arguments, expanding any directory via `Xcop::CLI.expand` (a new public class method that recursively globs `.xml`, `.xsd`, `.xhtml`, `.xsl`, `.html`). The extension list matches `Xcop::RakeTask`'s defaults, so CLI and rake behaviour stay in sync.
- `test/test_cli.rb`: Two new minitest cases — one for recursive expansion across nested directories and mixed extensions, one that confirms non-XML files (like `.txt`) are ignored.
- `features/cli.feature`: A cucumber scenario drives the full `bin/xcop` binary against a directory with a nested `.xsl` and asserts both files are reported as good.
- `README.md`: Replaces the `find`-based workaround with the new `xcop .` syntax.

## Verification

`bundle exec rake` locally on `ubuntu-24.04` with Ruby 3.3.6:

- `16 tests, 28 assertions, 0 failures, 0 errors, 0 skips`
- `8 scenarios (8 passed)`
- RuboCop: `13 files inspected, no offenses detected`

Ready for merge when you are.
