### PR TITLE
#17: strip unused xmlns declarations

### DIFF
--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -4,6 +4,7 @@
 require 'nokogiri'
 require 'differ'
 require 'rainbow'
+require 'set'
 require_relative 'version'
 
 # One document.
@@ -19,20 +20,48 @@ class Xcop::Document
 
   # Return the difference, if any (empty string if everything is clean).
   def diff(nocolor: false)
-    xml = Nokogiri::XML(File.open(@path), &:noblanks)
-    ideal = xml.to_xml(indent: 2)
     now = File.read(@path)
     differ(ideal, now, nocolor: nocolor)
   end
 
   # Fixes the document.
   def fix
-    xml = Nokogiri::XML(File.open(@path), &:noblanks)
-    ideal = xml.to_xml(indent: 2)
     File.write(@path, ideal)
   end
 
   private
+
+  # The canonical, well-formatted version of the document.
+  def ideal
+    xml = Nokogiri::XML(File.open(@path), &:noblanks)
+    text = xml.to_xml(indent: 2)
+    unused_namespace_prefixes(xml).each do |prefix|
+      text =
+        if prefix.nil?
+          text.gsub(/\s+xmlns="[^"]*"/, '')
+        else
+          text.gsub(/\s+xmlns:#{Regexp.escape(prefix)}="[^"]*"/, '')
+        end
+    end
+    Nokogiri::XML(text, &:noblanks).to_xml(indent: 2)
+  end
+
+  # Returns the set of namespace prefixes that are declared in +xml+
+  # but never referenced by any element or attribute. A +nil+ entry in
+  # the set represents the default namespace.
+  def unused_namespace_prefixes(xml)
+    used = Set.new
+    declared = Set.new
+    xml.traverse do |node|
+      next unless node.is_a?(Nokogiri::XML::Element)
+      used << node.namespace.prefix if node.namespace
+      node.attribute_nodes.each do |attr|
+        used << attr.namespace.prefix if attr.namespace
+      end
+      node.namespace_definitions.each { |ns| declared << ns.prefix }
+    end
+    declared - used
+  end
 
   def differ(ideal, fact, nocolor: false)
     return '' if ideal == fact

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -39,4 +39,76 @@ class TestXcop < Minitest::Test
       File.delete(f)
     end
   end
+
+  def test_fix_removes_unused_namespace
+    Dir.mktmpdir 'test_ns_unused' do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<a xmlns:x=\"#1\">\n</a>\n")
+      Xcop::Document.new(f).fix
+      refute_includes(
+        File.read(f),
+        'xmlns:x',
+        "Expected unused xmlns:x to be removed, got '#{File.read(f)}'"
+      )
+    end
+  end
+
+  def test_fix_removes_unused_namespace_on_nested_element
+    Dir.mktmpdir 'test_ns_nested' do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(
+        f,
+        "<?xml version=\"1.0\"?>\n<a>\n  <b xmlns:x=\"#1\"/>\n</a>\n"
+      )
+      Xcop::Document.new(f).fix
+      refute_includes(
+        File.read(f),
+        'xmlns:x',
+        "Expected unused xmlns:x on nested element to be removed, got '#{File.read(f)}'"
+      )
+    end
+  end
+
+  def test_fix_preserves_used_namespace_on_element
+    Dir.mktmpdir 'test_ns_used_el' do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(
+        f,
+        "<?xml version=\"1.0\"?>\n<a xmlns:x=\"#1\">\n  <x:child/>\n</a>\n"
+      )
+      Xcop::Document.new(f).fix
+      assert_includes(
+        File.read(f),
+        'xmlns:x="#1"',
+        "Expected xmlns:x to be preserved, got '#{File.read(f)}'"
+      )
+    end
+  end
+
+  def test_fix_preserves_used_namespace_on_attribute
+    Dir.mktmpdir 'test_ns_used_attr' do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(
+        f,
+        "<?xml version=\"1.0\"?>\n<a xmlns:y=\"#2\">\n  <b y:attr=\"hi\">text</b>\n</a>\n"
+      )
+      Xcop::Document.new(f).fix
+      assert_includes(
+        File.read(f),
+        'xmlns:y="#2"',
+        "Expected xmlns:y to be preserved, got '#{File.read(f)}'"
+      )
+    end
+  end
+
+  def test_diff_flags_unused_namespace
+    Dir.mktmpdir 'test_ns_diff' do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<a xmlns:x=\"#1\">\n</a>\n")
+      refute_empty(
+        Xcop::Document.new(f).diff(nocolor: true),
+        'Expected non-empty diff for a document with an unused namespace'
+      )
+    end
+  end
 end


### PR DESCRIPTION
@yegor256 this PR resolves #17.

## Why

`Xcop::Document#diff` and `#fix` used `Nokogiri::XML(..., &:noblanks).to_xml(indent: 2)` as the canonical form of a document, which preserved every `xmlns` declaration even when no element or attribute in the document referenced the prefix. As a result, a file like

```xml
<?xml version="1.0"?>
<a xmlns:x="#1">
</a>
```

was considered clean by `xcop`, contrary to the expectation in the ticket.

## What changed

- `lib/xcop/document.rb`: `#diff` and `#fix` now share a private `#ideal` helper. It serializes the document with Nokogiri, drops every declared prefix that nothing in the document uses (detected via `Nokogiri::XML::Node#namespace`, `#attribute_nodes`, and `#namespace_definitions`), and re-parses the result to normalize indentation. A default `xmlns="..."` is treated as used by the element that declares it, so it is preserved.
- `test/test_document.rb`: four new regression tests covering the example from the ticket, an unused declaration on a nested element, and preservation of prefixes referenced either by an element or by an attribute.

## Verification

- Reproduction first: the new tests in commit `378f7b0` fail on `master` and pass on this branch after `ba66fb8`.
- `bundle exec rake` is green locally and in CI — 21 tests / 38 assertions / 0 failures, 8 cucumber scenarios pass, RuboCop reports 0 offenses.

Ready for merge.