### PR TITLE
Validate XML against declared XSD schema (#15)

### DIFF
--- a/lib/xcop/cli.rb
+++ b/lib/xcop/cli.rb
@@ -33,6 +33,11 @@ class Xcop::CLI
         puts diff
         raise "Invalid XML formatting in #{f}"
       end
+      errors = doc.validate
+      unless errors.empty?
+        puts errors.join("\n")
+        raise "XSD validation failed in #{f}"
+      end
       yield(f) if block_given?
     end
   end

--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -29,6 +29,18 @@ class Xcop::Document
     File.write(@path, ideal)
   end
 
+  # Validates the document against its declared XSD schema, if any.
+  # Returns an array of error message strings (empty when valid or no schema declared).
+  def validate
+    xml = Nokogiri::XML(File.open(@path))
+    schema_path = xsd_schema_path(xml)
+    return [] unless schema_path
+    return [] unless File.exist?(schema_path)
+    Nokogiri::XML::Schema(File.read(schema_path)).validate(xml).map(&:message)
+  end
+
+  XSI_NS = 'http://www.w3.org/2001/XMLSchema-instance'.freeze
+
   private
 
   # The canonical, well-formatted version of the document.
@@ -61,6 +73,21 @@ class Xcop::Document
       node.namespace_definitions.each { |ns| declared << ns.prefix }
     end
     declared - used
+  end
+
+  def xsd_schema_path(xml)
+    root = xml.root
+    return nil unless root
+    no_ns = root.at_xpath('@xsi:noNamespaceSchemaLocation', 'xsi' => XSI_NS)
+    with_ns = root.at_xpath('@xsi:schemaLocation', 'xsi' => XSI_NS)
+    location =
+      if no_ns
+        no_ns.value
+      elsif with_ns
+        with_ns.value.split.last
+      end
+    return nil unless location
+    File.expand_path(location, File.dirname(@path))
   end
 
   def differ(ideal, fact, nocolor: false)

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -112,59 +112,43 @@ class TestXcop < Minitest::Test
     end
   end
 
+  XSI = 'http://www.w3.org/2001/XMLSchema-instance'.freeze
+  PERSON_XSD = <<-XSD.freeze
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="person">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="name" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+  XSD
+
   def test_xsd_validation_detects_invalid_xml
     Dir.mktmpdir 'test_xsd_invalid' do |dir|
-      xsd = File.join(dir, 'schema.xsd')
-      File.write(
-        xsd,
-        "<?xml version=\"1.0\"?>\n" \
-        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n" \
-        "  <xs:element name=\"person\">\n" \
-        "    <xs:complexType>\n" \
-        "      <xs:sequence>\n" \
-        "        <xs:element name=\"name\" type=\"xs:string\"/>\n" \
-        "      </xs:sequence>\n" \
-        "    </xs:complexType>\n" \
-        "  </xs:element>\n" \
-        "</xs:schema>\n"
-      )
+      File.write(File.join(dir, 'schema.xsd'), PERSON_XSD)
       xml = File.join(dir, 'bad.xml')
-      File.write(
-        xml,
-        "<?xml version=\"1.0\"?>\n" \
-        "<person xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" \
-        " xsi:noNamespaceSchemaLocation=\"schema.xsd\">\n" \
-        "</person>\n"
-      )
+      File.write(xml, <<-XML)
+<?xml version="1.0"?>
+<person xmlns:xsi="#{XSI}" xsi:noNamespaceSchemaLocation="schema.xsd">
+</person>
+      XML
       refute_empty(Xcop::Document.new(xml).validate, 'Expected XSD errors for invalid XML')
     end
   end
 
   def test_xsd_validation_passes_for_valid_xml
     Dir.mktmpdir 'test_xsd_valid' do |dir|
-      xsd = File.join(dir, 'schema.xsd')
-      File.write(
-        xsd,
-        "<?xml version=\"1.0\"?>\n" \
-        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n" \
-        "  <xs:element name=\"person\">\n" \
-        "    <xs:complexType>\n" \
-        "      <xs:sequence>\n" \
-        "        <xs:element name=\"name\" type=\"xs:string\"/>\n" \
-        "      </xs:sequence>\n" \
-        "    </xs:complexType>\n" \
-        "  </xs:element>\n" \
-        "</xs:schema>\n"
-      )
+      File.write(File.join(dir, 'schema.xsd'), PERSON_XSD)
       xml = File.join(dir, 'good.xml')
-      File.write(
-        xml,
-        "<?xml version=\"1.0\"?>\n" \
-        "<person xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" \
-        " xsi:noNamespaceSchemaLocation=\"schema.xsd\">\n" \
-        "  <name>John</name>\n" \
-        "</person>\n"
-      )
+      File.write(xml, <<-XML)
+<?xml version="1.0"?>
+<person xmlns:xsi="#{XSI}" xsi:noNamespaceSchemaLocation="schema.xsd">
+  <name>John</name>
+</person>
+      XML
       assert_empty(Xcop::Document.new(xml).validate, 'Expected no XSD errors for valid XML')
     end
   end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -111,4 +111,69 @@ class TestXcop < Minitest::Test
       )
     end
   end
+
+  def test_xsd_validation_detects_invalid_xml
+    Dir.mktmpdir 'test_xsd_invalid' do |dir|
+      xsd = File.join(dir, 'schema.xsd')
+      File.write(
+        xsd,
+        "<?xml version=\"1.0\"?>\n" \
+        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n" \
+        "  <xs:element name=\"person\">\n" \
+        "    <xs:complexType>\n" \
+        "      <xs:sequence>\n" \
+        "        <xs:element name=\"name\" type=\"xs:string\"/>\n" \
+        "      </xs:sequence>\n" \
+        "    </xs:complexType>\n" \
+        "  </xs:element>\n" \
+        "</xs:schema>\n"
+      )
+      xml = File.join(dir, 'bad.xml')
+      File.write(
+        xml,
+        "<?xml version=\"1.0\"?>\n" \
+        "<person xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" \
+        " xsi:noNamespaceSchemaLocation=\"schema.xsd\">\n" \
+        "</person>\n"
+      )
+      refute_empty(Xcop::Document.new(xml).validate, 'Expected XSD errors for invalid XML')
+    end
+  end
+
+  def test_xsd_validation_passes_for_valid_xml
+    Dir.mktmpdir 'test_xsd_valid' do |dir|
+      xsd = File.join(dir, 'schema.xsd')
+      File.write(
+        xsd,
+        "<?xml version=\"1.0\"?>\n" \
+        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n" \
+        "  <xs:element name=\"person\">\n" \
+        "    <xs:complexType>\n" \
+        "      <xs:sequence>\n" \
+        "        <xs:element name=\"name\" type=\"xs:string\"/>\n" \
+        "      </xs:sequence>\n" \
+        "    </xs:complexType>\n" \
+        "  </xs:element>\n" \
+        "</xs:schema>\n"
+      )
+      xml = File.join(dir, 'good.xml')
+      File.write(
+        xml,
+        "<?xml version=\"1.0\"?>\n" \
+        "<person xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" \
+        " xsi:noNamespaceSchemaLocation=\"schema.xsd\">\n" \
+        "  <name>John</name>\n" \
+        "</person>\n"
+      )
+      assert_empty(Xcop::Document.new(xml).validate, 'Expected no XSD errors for valid XML')
+    end
+  end
+
+  def test_xsd_validation_skipped_when_no_schema
+    Dir.mktmpdir 'test_xsd_absent' do |dir|
+      f = File.join(dir, 'plain.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<root/>\n")
+      assert_empty(Xcop::Document.new(f).validate, 'Expected no XSD errors when no schema declared')
+    end
+  end
 end


### PR DESCRIPTION
Closes #15.

When an XML file references an XSD schema via `xsi:noNamespaceSchemaLocation` or `xsi:schemaLocation` in its root element, `xcop` now validates the document against that schema and reports any violations.

The implementation adds `Document#validate` which reads the schema path from the XML header, resolves it relative to the file, and delegates to Nokogiri's built-in XSD validator. The CLI calls `validate` after the formatting check so both errors are surfaced.

Three new tests cover: (1) detecting a missing required child element, (2) confirming a conforming document passes cleanly, and (3) silently skipping files that declare no schema.