### PR TITLE
#88: keep UTF-8 text unescaped

### DIFF
--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -20,7 +20,7 @@ class Xcop::Document
 
   # Return the difference, if any (empty string if everything is clean).
   def diff(nocolor: false)
-    now = File.read(@path)
+    now = File.read(@path, encoding: Encoding::UTF_8)
     differ(ideal, now, nocolor: nocolor)
   end
 
@@ -46,7 +46,8 @@ class Xcop::Document
   # The canonical, well-formatted version of the document.
   def ideal
     xml = Nokogiri::XML(File.open(@path), &:noblanks)
-    text = xml.to_xml(indent: 2)
+    missing_encoding = xml.encoding.nil?
+    text = xml_to_text(xml, missing_encoding)
     unused_namespace_prefixes(xml).each do |prefix|
       text =
         if prefix.nil?
@@ -55,7 +56,15 @@ class Xcop::Document
           text.gsub(/\s+xmlns:#{Regexp.escape(prefix)}="[^"]*"/, '')
         end
     end
-    Nokogiri::XML(text, &:noblanks).to_xml(indent: 2)
+    xml_to_text(Nokogiri::XML(text, &:noblanks), missing_encoding)
+  end
+
+  def xml_to_text(xml, missing_encoding)
+    return xml.to_xml(indent: 2) unless missing_encoding
+    xml.to_xml(indent: 2, encoding: 'UTF-8').sub(
+      /^<\?xml version="1\.0" encoding="UTF-8"\?>/,
+      '<?xml version="1.0"?>'
+    )
   end
 
   # Returns the set of namespace prefixes that are declared in +xml+

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -30,6 +30,17 @@ class TestXcop < Minitest::Test
     end
   end
 
+  def test_keeps_utf8_text_without_encoding_declaration
+    Dir.mktmpdir 'test_utf8' do |dir|
+      f = File.join(dir, 'utf8.xml')
+      File.write(
+        f,
+        "<?xml version=\"1.0\"?>\n<a>\n  <b>Fabr\u00EDcio</b>\n</a>\n"
+      )
+      assert_equal('', Xcop::Document.new(f).diff(nocolor: true))
+    end
+  end
+
   def test_fixes_document
     Dir.mktmpdir 'test3' do |dir|
       f = File.join(dir, 'bad.xml')


### PR DESCRIPTION
Fixes #88.

Summary:
- Treat XML documents without an explicit encoding declaration as UTF-8 while formatting, without adding an `encoding` attribute to the declaration.
- Read the source text as UTF-8 for the diff comparison.
- Add a regression for the reported `Fabrício` text case.

Validation:
- `mise x ruby@3.3.11 -- bundle exec ruby -Itest test/test_document.rb` -> 12 runs, 21 assertions, 0 failures, 0 errors.
- Direct CLI repro with `<?xml version="1.0"?>` and `Fabrício` -> `looks good`.
- `mise x ruby@3.3.11 -- bundle exec rake` -> 25 tests, 45 assertions, 0 failures, 0 errors; 8 Cucumber scenarios passed; RuboCop inspected 13 files with no offenses.
- `git diff --check` -> passed.
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

Limitations:
- I did not test non-UTF-8 XML documents; this change targets the no-declaration default UTF-8 case from the issue.