### PR TITLE
Enforce canonical XML comment formatting

### DIFF
--- a/features/comments.feature
+++ b/features/comments.feature
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2017-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+Feature: Comment Formatting
+  As an author of XML I want XCOP to enforce
+  a single canonical layout for XML comments
+
+  Scenario: Messy single-line comment is rejected
+    Given I have a "single.xml" file with content:
+    """
+    <?xml version="1.0"?>
+    <a>
+      <!--   text   -->
+    </a>
+
+    """
+    When I run bin/xcop with "single.xml"
+    Then Exit code is not zero
+
+  Scenario: Messy single-line comment is fixed
+    Given I have a "single.xml" file with content:
+    """
+    <?xml version="1.0"?>
+    <a>
+      <!--   text   -->
+    </a>
+
+    """
+    When I run bin/xcop with "--fix single.xml"
+    Then Exit code is zero
+    And I run bin/xcop with "single.xml"
+    Then Exit code is zero
+    And Stdout contains "single.xml looks good"
+
+  Scenario: Over-indented multi-line comment is rejected
+    Given I have a "multi.xml" file with content:
+    """
+    <?xml version="1.0"?>
+    <a>
+      <!--
+          line1
+          line2
+      -->
+    </a>
+
+    """
+    When I run bin/xcop with "multi.xml"
+    Then Exit code is not zero
+
+  Scenario: Over-indented multi-line comment is fixed
+    Given I have a "multi.xml" file with content:
+    """
+    <?xml version="1.0"?>
+    <a>
+      <!--
+          line1
+          line2
+      -->
+    </a>
+
+    """
+    When I run bin/xcop with "--fix multi.xml"
+    Then Exit code is zero
+    And I run bin/xcop with "multi.xml"
+    Then Exit code is zero
+    And Stdout contains "multi.xml looks good"

--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -51,7 +51,7 @@ class Xcop::Document
   # The canonical, well-formatted version of the document.
   def ideal
     xml = Nokogiri::XML(File.read(@path), &:noblanks)
-    recomment(xml)
+    reshape(xml)
     text = xml.to_xml(indent: 2)
     unused(xml).each do |prefix|
       text =
@@ -70,7 +70,7 @@ class Xcop::Document
   # single line as +<!-- text -->+. A comment whose text spans several
   # lines is re-emitted with +<!--+ and +-->+ each alone on their own
   # line and every body line trimmed to the comment's own indent.
-  def recomment(xml)
+  def reshape(xml)
     xml.traverse do |node|
       next unless node.comment?
       node.native_content = canonical(node)

--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -51,6 +51,7 @@ class Xcop::Document
   # The canonical, well-formatted version of the document.
   def ideal
     xml = Nokogiri::XML(File.read(@path), &:noblanks)
+    recomment(xml)
     text = xml.to_xml(indent: 2)
     unused(xml).each do |prefix|
       text =
@@ -61,6 +62,42 @@ class Xcop::Document
         end
     end
     Nokogiri::XML(text, &:noblanks).to_xml(indent: 2)
+  end
+
+  # Rewrites every comment node into one of two canonical shapes so that
+  # +diff+ and +--fix+ can report and correct sloppy comment layout. A
+  # comment whose text has no end-of-line character is collapsed onto a
+  # single line as +<!-- text -->+. A comment whose text spans several
+  # lines is re-emitted with +<!--+ and +-->+ each alone on their own
+  # line and every body line trimmed to the comment's own indent.
+  def recomment(xml)
+    xml.traverse do |node|
+      next unless node.comment?
+      node.native_content = canonical(node)
+    end
+  end
+
+  # The canonical inner text (the part between +<!--+ and +-->+) for a
+  # single comment node, indented to match the node's depth.
+  def canonical(node)
+    raw = node.content
+    body = raw.strip
+    return " #{body} " unless raw.include?("\n")
+    indent = '  ' * depth(node)
+    body = body.split("\n").map { |line| line.strip.empty? ? '' : indent + line.strip }.join("\n")
+    "\n#{body}\n#{indent}"
+  end
+
+  # The number of ancestor elements of +node+, which equals the number
+  # of two-space indentation levels that +to_xml+ places before it.
+  def depth(node)
+    levels = 0
+    parent = node.parent
+    while parent && parent.element?
+      levels += 1
+      parent = parent.parent
+    end
+    levels
   end
 
   # Returns the set of namespace prefixes that are declared in +xml+

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -181,6 +181,48 @@ class TestXcop < Minitest::Test
     end
   end
 
+  def test_fix_collapses_single_line_comment
+    Dir.mktmpdir('test_comment_single') do |dir|
+      f = File.join(dir, 'c.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<a>\n  <!--   text   -->\n</a>\n")
+      Xcop::Document.new(f).fix
+      got = File.read(f)
+      assert_includes(got, '<!-- text -->', "Expected single-line comment to be collapsed, got '#{got}'")
+    end
+  end
+
+  def test_fix_reshapes_multi_line_comment
+    Dir.mktmpdir('test_comment_multi') do |dir|
+      f = File.join(dir, 'c.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<a>\n  <!-- line1\n       line2 -->\n</a>\n")
+      Xcop::Document.new(f).fix
+      assert_equal(
+        "<?xml version=\"1.0\"?>\n<a>\n  <!--\n  line1\n  line2\n  -->\n</a>\n",
+        File.read(f),
+        "Expected multi-line comment to be reshaped, got '#{File.read(f)}'"
+      )
+    end
+  end
+
+  def test_diff_flags_messy_comment
+    Dir.mktmpdir('test_comment_diff') do |dir|
+      f = File.join(dir, 'c.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<a>\n  <!--messy-->\n</a>\n")
+      refute_empty(
+        Xcop::Document.new(f).diff(nocolor: true),
+        'Expected non-empty diff for a document with a badly formatted comment'
+      )
+    end
+  end
+
+  def test_fix_leaves_canonical_comments_untouched
+    Dir.mktmpdir('test_comment_ok') do |dir|
+      f = File.join(dir, 'c.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<a>\n  <!-- text -->\n  <!--\n  line1\n  line2\n  -->\n</a>\n")
+      assert_equal(:untouched, Xcop::Document.new(f).fix, 'Expected already-canonical comments to be left untouched')
+    end
+  end
+
   def test_diff_leaves_no_open_handle
     Dir.mktmpdir('test_diff_leak') do |dir|
       f = File.join(dir, 'a.xml')


### PR DESCRIPTION
Closes #157.

## Problem

`xcop` normalizes indentation and strips unused namespaces, but it left XML comment formatting untouched. `Xcop::Document#ideal` parses with Nokogiri and re-emits via `to_xml`, and comment nodes passed through verbatim — so `diff` never flagged a messy comment and `--fix` never rewrote one. A sloppy one-liner like `<!--   text   -->` and an over-indented multi-line comment both survived a `--fix` unchanged.

## Fix

A new `reshape` pass in `ideal` walks every `Nokogiri::XML::Comment` node and rewrites its text into one of two canonical shapes before rendering, then lets the existing diff/`--fix` flow report and correct violations:

- **Single-line** (no end-of-line inside): collapsed to `<!-- text -->`.
- **Multi-line**: `<!--` and `-->` each alone on their own line, with every body line trimmed to the comment's own indent (computed from the node's element depth so it matches `to_xml`'s two-space indentation).

The transformation is idempotent — an already-canonical file reports `:untouched`.

### Before → after

```xml
<!--   text   -->              →  <!-- text -->

<!--                              <!--
    line1                         line1
    line2                         line2
-->                               -->
```

## Tests

- `test/test_document.rb`: single-line collapse, multi-line reshape, `diff` flagging a messy comment, and canonical comments left untouched.
- `features/comments.feature`: end-to-end scenarios for both shapes, covering both rejection (non-zero exit) and `--fix` correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)