### PR TITLE
fix(document): #161 keep namespaces referenced only from XPath attributes

### DIFF
--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -103,6 +103,14 @@ class Xcop::Document
   # Returns the set of namespace prefixes that are declared in +xml+
   # but never referenced by any element or attribute. A +nil+ entry in
   # the set represents the default namespace.
+  #
+  # A prefix counts as "used" not only when it appears as an element or
+  # attribute QName, but also when it is referenced from an attribute
+  # value as a +prefix:+ token. XSLT and XPath routinely mention a
+  # prefix only inside +select+, +test+, +match+, +as+, +use+ and
+  # similar attributes (e.g. +as="xs:integer"+ or +select="eo:foo()"+),
+  # so stripping such a "declared but not QName-used" prefix would break
+  # the stylesheet. See #161.
   def unused(xml)
     used = Set.new
     declared = Set.new
@@ -111,6 +119,7 @@ class Xcop::Document
       used << node.namespace.prefix if node.namespace
       node.attribute_nodes.each do |attr|
         used << attr.namespace.prefix if attr.namespace
+        attr.value.scan(/([A-Za-z_][\w.-]*):/) { |m| used << m.first }
       end
       node.namespace_definitions.each { |ns| declared << ns.prefix }
     end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -109,6 +109,42 @@ class TestXcop < Minitest::Test
     end
   end
 
+  def test_fix_keeps_xpath_attribute_namespace
+    Dir.mktmpdir('test_ns_used_xpath') do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(f, <<-XML)
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0">
+  <xsl:variable name="n" as="xs:integer" select="1"/>
+</xsl:stylesheet>
+      XML
+      Xcop::Document.new(f).fix
+      assert_includes(
+        File.read(f),
+        'xmlns:xs=',
+        "Expected xmlns:xs referenced only from an XPath attribute to be preserved, got '#{File.read(f)}'"
+      )
+    end
+  end
+
+  def test_fix_keeps_function_call_namespace
+    Dir.mktmpdir('test_ns_used_fn') do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(f, <<-XML)
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="urn:eo" version="2.0">
+  <xsl:value-of select="eo:foo(.)"/>
+</xsl:stylesheet>
+      XML
+      Xcop::Document.new(f).fix
+      assert_includes(
+        File.read(f),
+        'xmlns:eo=',
+        "Expected xmlns:eo referenced only from a function call to be preserved, got '#{File.read(f)}'"
+      )
+    end
+  end
+
   def test_diff_flags_unused_namespace
     Dir.mktmpdir('test_ns_diff') do |dir|
       f = File.join(dir, 'ns.xml')


### PR DESCRIPTION
Closes #161.

## Problem

Both `xcop --fix` and the plain checker deleted namespace declarations that were actually in use, corrupting XSLT stylesheets.

`Document#unused` (`lib/xcop/document.rb`) built the set of "used" prefixes purely from element and attribute *QNames* (`node.namespace.prefix`, `attr.namespace.prefix`). But a prefix can also be referenced from XPath inside an attribute *value* — `select`, `test`, `match`, `as`, `use`, or a function call such as `eo:foo(...)`. Since `unused` never looked at attribute values, any XPath-only prefix was judged unused, and `ideal` then stripped it from the serialized text. Running `--fix` on a stylesheet with `as="xs:integer"` removed `xmlns:xs` while leaving the reference intact, producing a stylesheet that references an undeclared prefix and no longer compiles.

## Fix

Before deeming a prefix unused, `unused` now also scans each attribute value for `prefix:` tokens and adds them to the `used` set. This covers XPath-bearing attributes and function calls without special-casing individual attribute names.

## Tests

Added two regression tests to `test/test_document.rb`:
- `test_fix_keeps_xpath_attribute_namespace` — `xmlns:xs` used only via `as="xs:integer"` is preserved.
- `test_fix_keeps_function_call_namespace` — `xmlns:eo` used only via `select="eo:foo(.)"` is preserved.

Full `test_document.rb` suite (22 runs, 36 assertions) passes and rubocop is clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWF9DJNrVrrnBm2r8y4mhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWF9DJNrVrrnBm2r8y4mhx)_