### PR TITLE
fix(document): #163 skip validation for remote schema locations

### DIFF
--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -126,6 +126,16 @@ class Xcop::Document
     declared - used
   end
 
+  # Returns the absolute path of the local XSD schema declared by +xml+,
+  # or +nil+ when no schema is declared or the declared location is not a
+  # local file. The location comes from +xsi:noNamespaceSchemaLocation+
+  # or, failing that, from the second token of +xsi:schemaLocation+.
+  #
+  # A +schemaLocation+ is a URI, not a file path, so a remote schema such
+  # as +http://maven.apache.org/xsd/maven-4.0.0.xsd+ (the normal case for
+  # Maven +pom.xml+, +settings.xml+ and +site.xml+) must not be treated as
+  # a local file. Any location that carries a URL scheme is therefore
+  # skipped, leaving only truly local schemas to be validated. See #163.
   def schema(xml)
     root = xml.root
     return unless root
@@ -138,6 +148,7 @@ class Xcop::Document
         mapped.value.split.last
       end
     return unless location
+    return if location.match?(%r{\A[a-z][a-z0-9+.-]*://}i)
     File.expand_path(location, File.dirname(@path))
   end
 

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -217,6 +217,38 @@ class TestXcop < Minitest::Test
     end
   end
 
+  def test_xsd_validation_skipped_for_remote_schema
+    Dir.mktmpdir('test_xsd_remote') do |dir|
+      xml = File.join(dir, 'pom.xml')
+      File.write(xml, <<-XML)
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="#{XSI}"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+</project>
+      XML
+      assert_empty(
+        Xcop::Document.new(xml).validate,
+        'Expected no XSD errors when schemaLocation points at a remote URL'
+      )
+    end
+  end
+
+  def test_xsd_skipped_for_remote_plain_schema
+    Dir.mktmpdir('test_xsd_remote_plain') do |dir|
+      xml = File.join(dir, 'doc.xml')
+      File.write(xml, <<-XML)
+<?xml version="1.0"?>
+<person xmlns:xsi="#{XSI}" xsi:noNamespaceSchemaLocation="https://example.com/person.xsd">
+</person>
+      XML
+      assert_empty(
+        Xcop::Document.new(xml).validate,
+        'Expected no XSD errors when noNamespaceSchemaLocation points at a remote URL'
+      )
+    end
+  end
+
   def test_fix_collapses_single_line_comment
     Dir.mktmpdir('test_comment_single') do |dir|
       f = File.join(dir, 'c.xml')


### PR DESCRIPTION
Fixes #163.

## Problem

`xcop` failed on any XML file whose `xsi:schemaLocation` (or `xsi:noNamespaceSchemaLocation`) points at a remote schema — the normal case for Maven `pom.xml`, `settings.xml` and `site.xml`. The `schema` method took the location and unconditionally passed it to `File.expand_path`, so a URL like `http://maven.apache.org/xsd/maven-4.0.0.xsd` became a bogus local path such as `/repo/http:/maven.apache.org/xsd/maven-4.0.0.xsd`. `validate` then found no such file and returned `schema file is absent`, making xcop exit non-zero on well-formed, valid XML.

## Fix

`xsi:schemaLocation` is a URI, not a file path. In `lib/xcop/document.rb` the `schema` method now returns `nil` when the location carries a URL scheme (`%r{\A[a-z][a-z0-9+.-]*://}i`) before calling `File.expand_path`, so only schemas that resolve to a real local file are validated. This is the narrowest fix proposed in the issue.

## Tests

Added two tests in `test/test_document.rb`:
- `test_xsd_validation_skipped_for_remote_schema` — a Maven-style `pom.xml` with a remote `xsi:schemaLocation` validates cleanly.
- `test_xsd_skipped_for_remote_plain_schema` — a remote `xsi:noNamespaceSchemaLocation` is likewise skipped.

Existing local-schema validation behaviour (valid/invalid/absent) is unchanged. All 24 document tests pass and RuboCop is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpkN2rAHHk1ZtWsJKhUV1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpkN2rAHHk1ZtWsJKhUV1F)_