### PR TITLE
fix(document): #165 keep namespaces named in exclude-result-prefixes

### DIFF
--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -46,6 +46,8 @@ class Xcop::Document
 
   XSI_NS = 'http://www.w3.org/2001/XMLSchema-instance'.freeze
 
+  PREFIX_LISTS = %w[exclude-result-prefixes extension-element-prefixes].freeze
+
   private
 
   # The canonical, well-formatted version of the document.
@@ -110,7 +112,13 @@ class Xcop::Document
   # prefix only inside +select+, +test+, +match+, +as+, +use+ and
   # similar attributes (e.g. +as="xs:integer"+ or +select="eo:foo()"+),
   # so stripping such a "declared but not QName-used" prefix would break
-  # the stylesheet. See #161.
+  # the stylesheet. See #161. A prefix is used, too, when it is named in an
+  # +exclude-result-prefixes+ or +extension-element-prefixes+ attribute;
+  # these list bare prefixes with no colon, so the +prefix:+ scan never
+  # catches them, yet XSLT requires every prefix named there to resolve to
+  # a declared namespace (dropping the declaration is the static error
+  # XTSE0808). The token +#default+ refers to the default namespace. See
+  # #165.
   def unused(xml)
     used = Set.new
     declared = Set.new
@@ -120,6 +128,8 @@ class Xcop::Document
       node.attribute_nodes.each do |attr|
         used << attr.namespace.prefix if attr.namespace
         attr.value.scan(/([A-Za-z_][\w.-]*):/) { |m| used << m.first }
+        next unless PREFIX_LISTS.include?(attr.name)
+        attr.value.split.each { |token| used << (token == '#default' ? nil : token) }
       end
       node.namespace_definitions.each { |ns| declared << ns.prefix }
     end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -145,6 +145,42 @@ class TestXcop < Minitest::Test
     end
   end
 
+  def test_fix_keeps_exclude_result_prefixes_namespace
+    Dir.mktmpdir('test_ns_used_erp') do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(f, <<-XML)
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" version="2.0">
+  <xsl:template match="/"/>
+</xsl:stylesheet>
+      XML
+      Xcop::Document.new(f).fix
+      assert_includes(
+        File.read(f),
+        'xmlns:xs=',
+        "Expected xmlns:xs named in exclude-result-prefixes to be preserved, got '#{File.read(f)}'"
+      )
+    end
+  end
+
+  def test_fix_keeps_extension_prefixes_namespace
+    Dir.mktmpdir('test_ns_used_eep') do |dir|
+      f = File.join(dir, 'ns.xml')
+      File.write(f, <<-XML)
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="urn:my" extension-element-prefixes="my" version="2.0">
+  <xsl:template match="/"/>
+</xsl:stylesheet>
+      XML
+      Xcop::Document.new(f).fix
+      assert_includes(
+        File.read(f),
+        'xmlns:my=',
+        "Expected xmlns:my named in extension-element-prefixes to be preserved, got '#{File.read(f)}'"
+      )
+    end
+  end
+
   def test_diff_flags_unused_namespace
     Dir.mktmpdir('test_ns_diff') do |dir|
       f = File.join(dir, 'ns.xml')


### PR DESCRIPTION
Closes #165.

## Problem

`xcop --fix` deleted an `xmlns:` declaration whose prefix is listed in an XSLT `exclude-result-prefixes` (or `extension-element-prefixes`) attribute, producing a stylesheet that no longer compiles.

The `unused` method in `lib/xcop/document.rb` collected "used" prefixes from element/attribute QNames and (since #161) from `prefix:` tokens in attribute values. But `exclude-result-prefixes` lists **bare** prefixes with no colon (`exclude-result-prefixes="xs"`), so the `prefix:` scan never matched them — the prefix was judged unused and its declaration stripped. XSLT requires every prefix named there to resolve to a declared, in-scope namespace, otherwise it is the static error XTSE0808 and the processor rejects the stylesheet.

## Fix

`unused` now treats every whitespace-separated token from an `exclude-result-prefixes` or `extension-element-prefixes` attribute as a used prefix, so those declarations are never stripped. The token `#default` maps to the default-namespace entry (`nil`).

## Changes

- `lib/xcop/document.rb`: added the `PREFIX_LISTS` constant and extended `unused` to fold each token from those attributes into the `used` set.
- `test/test_document.rb`: added `test_fix_keeps_exclude_result_prefixes_namespace` and `test_fix_keeps_extension_prefixes_namespace`.

All 26 document tests pass and RuboCop is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AbUEAD6tcwgjq2pSs3XoE

---
_Generated by [Claude Code](https://claude.ai/code/session_018AbUEAD6tcwgjq2pSs3XoE)_