### PR TITLE
Check current directory when xcop runs with no files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ xcop .
 xcop --fix src/resources
 ```
 
+When you run `xcop` without any files, directories, or `--include`
+globs, it checks the current directory, exactly as if you called
+`xcop .`:
+
+```bash
+xcop
+```
+
 ## Defaults
 
 You can put command line options into a `.xcop` file in the directory

--- a/bin/xcop
+++ b/bin/xcop
@@ -56,7 +56,9 @@ if opts[:include]
   end
 end
 
-files += opts.arguments.map { |f| File.expand_path(f) }
+targets = opts.arguments
+targets = ['.'] if targets.empty? && Array(opts[:include]).empty?
+files += targets.map { |f| File.expand_path(f) }
 
 if opts[:exclude]
   opts[:exclude].each do |glob|

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -44,6 +44,24 @@ Feature: Command Line Processing
     Then I run bin/xcop with "broken.xml"
     Then Exit code is zero
 
+  Scenario: Validating all files in the current directory by default
+    Given I have a "auto.xml" file with content:
+    """
+    <?xml version="1.0"?>
+    <hello>Hello, world!</hello>
+
+    """
+    And I have a "nested/deep.xsl" file with content:
+    """
+    <?xml version="1.0"?>
+    <hello>Hello, world!</hello>
+
+    """
+    When I run bin/xcop with ""
+    Then Stdout contains "auto.xml looks good"
+    And Stdout contains "deep.xsl looks good"
+    And Exit code is zero
+
   Scenario: Validating a directory of XML files recursively
     Given I have a "pkg/top.xml" file with content:
     """


### PR DESCRIPTION
Running `xcop` with no arguments used to check nothing and exit with success, which quietly hid unformatted files. Now a bare `xcop` defaults to the current directory, exactly as if you had typed `xcop .`, so it recursively validates every `.xml`, `.xsd`, `.xhtml`, `.xsl`, and `.html` file.

The default kicks in only when you pass no files, no directories, and no `--include` globs, so every existing invocation keeps behaving as before. A new cucumber scenario covers the case, and the README documents the behavior.

Closes #171