### PR TITLE
Skip non-XML files while checking, not only while fixing

### DIFF
--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -17,3 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: yegor256/copyrights-action@0.0.12
+        with:
+          ignore: >-
+            fixtures/**
+            target/**
+            node_modules/**
+            .git/**

--- a/bin/xcop
+++ b/bin/xcop
@@ -76,8 +76,12 @@ if opts.fix?
   end
 else
   begin
-    Xcop::CLI.new(files, nocolor: opts.nocolor?).run do |f|
-      puts "#{f} looks good" unless opts.quiet?
+    Xcop::CLI.new(files, nocolor: opts.nocolor?).run do |f, status|
+      if status == :malformed
+        puts "#{f} is not a well-formed XML, skipping it"
+      elsif !opts.quiet?
+        puts "#{f} looks good"
+      end
     end
   rescue StandardError => e
     puts e.message

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -54,6 +54,15 @@ Feature: Command Line Processing
     And Exit code is zero
     And The file "garbage.xml" contains "this is not XML"
 
+  Scenario: Skipping a plain text file while checking
+    Given I have a "foo.txt" file with content:
+    """
+    not xml at all
+    """
+    When I run bin/xcop with "foo.txt"
+    Then Stdout contains "is not a well-formed XML, skipping it"
+    And Exit code is zero
+
   Scenario: Validating all files in the current directory by default
     Given I have a "auto.xml" file with content:
     """

--- a/lib/xcop/cli.rb
+++ b/lib/xcop/cli.rb
@@ -24,9 +24,16 @@ class Xcop::CLI
     EXTENSIONS.flat_map { |ext| Dir.glob(File.join(dir, '**', "*.#{ext}")) }.sort
   end
 
+  # Check them all. The block, when given, receives the file path and a
+  # status symbol that is +:good+ when the file is clean and
+  # +:malformed+ when the file is not XML at all and was skipped.
   def run
     @files.each do |f|
       doc = Xcop::Document.new(f)
+      unless doc.wellformed?
+        yield(f, :malformed) if block_given?
+        next
+      end
       diff = doc.diff(nocolor: @nocolor)
       unless diff.empty?
         puts(diff)
@@ -37,7 +44,7 @@ class Xcop::CLI
         puts(errors.join("\n"))
         raise(StandardError, "XSD validation failed in #{f}")
       end
-      yield(f) if block_given?
+      yield(f, :good) if block_given?
     end
   end
 

--- a/lib/xcop/document.rb
+++ b/lib/xcop/document.rb
@@ -18,6 +18,15 @@ class Xcop::Document
     @path = path
   end
 
+  # Is the document well-formed XML? Nokogiri parses in recover mode
+  # and never raises, so a broken file yields a rootless document that
+  # +to_xml+ renders as an empty declaration; a fatal parse error is
+  # the signal that the file is not XML and thus can neither be
+  # reformatted nor sensibly compared to its ideal. See #173 and #175.
+  def wellformed?
+    Nokogiri::XML(File.read(@path)).errors.none?(&:fatal?)
+  end
+
   # Return the difference, if any (empty string if everything is clean).
   def diff(nocolor: false)
     differ(ideal, File.read(@path), nocolor: nocolor)
@@ -51,14 +60,6 @@ class Xcop::Document
   PREFIX_LISTS = %w[exclude-result-prefixes extension-element-prefixes].freeze
 
   private
-
-  # Is the document well-formed XML? Nokogiri parses in recover mode
-  # and never raises, so a broken file yields a rootless document that
-  # +to_xml+ renders as an empty declaration; a fatal parse error is
-  # the signal that the file cannot be safely reformatted. See #173.
-  def wellformed?
-    Nokogiri::XML(File.read(@path)).errors.none?(&:fatal?)
-  end
 
   # The canonical, well-formatted version of the document.
   def ideal

--- a/lib/xcop/rake_task.rb
+++ b/lib/xcop/rake_task.rb
@@ -35,8 +35,8 @@ class Xcop::RakeTask < Rake::TaskLib
     good = Dir.glob(@includes).reject { |f| bad.include?(f) }
     puts("Inspecting #{pluralize(good.length, 'file')}...") unless @quiet
     begin
-      Xcop::CLI.new(good).run do
-        print(Rainbow('.').green) unless @quiet
+      Xcop::CLI.new(good).run do |_f, status|
+        print(status == :malformed ? Rainbow('?').yellow : Rainbow('.').green) unless @quiet
       end
     rescue StandardError => e
       puts(e.message)

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -93,6 +93,35 @@ class CLITest < Minitest::Test
     end
   end
 
+  def test_run_skips_plain_text_file
+    Dir.mktmpdir('test_run_text') do |dir|
+      f = File.join(dir, 'notes.txt')
+      File.write(f, "not xml at all\n")
+      status = nil
+      Xcop::CLI.new([f]).run { |_file, sym| status = sym }
+      assert_equal(:malformed, status, "Expected '#{f}' to be reported malformed, got '#{status}'")
+    end
+  end
+
+  def test_run_doesnt_fail_on_plain_text_file
+    Dir.mktmpdir('test_run_text_quiet') do |dir|
+      f = File.join(dir, 'notes.txt')
+      File.write(f, "not xml at all\n")
+      cli = Xcop::CLI.new([f])
+      assert_silent { cli.run }
+    end
+  end
+
+  def test_run_reports_good_status_for_canonical_file
+    Dir.mktmpdir('test_run_good') do |dir|
+      f = File.join(dir, 'good.xml')
+      File.write(f, "<?xml version=\"1.0\"?>\n<root>\n  <item>1</item>\n</root>\n")
+      status = nil
+      Xcop::CLI.new([f]).run { |_file, sym| status = sym }
+      assert_equal(:good, status, "Expected '#{f}' to be reported good, got '#{status}'")
+    end
+  end
+
   def test_fix_valid_file_no_changes
     Dir.mktmpdir('test_no_fix') do |dir|
       f = File.join(dir, 'valid.xml')

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -48,6 +48,28 @@ class TestXcop < Minitest::Test
     end
   end
 
+  def test_reports_plain_text_as_not_wellformed
+    Dir.mktmpdir('test_not_wellformed') do |dir|
+      f = File.join(dir, 'notes.txt')
+      File.write(f, "not xml at all\n")
+      refute_predicate(
+        Xcop::Document.new(f), :wellformed?,
+        'Expected a plain text file to be reported as not well-formed XML'
+      )
+    end
+  end
+
+  def test_reports_xml_as_wellformed
+    Dir.mktmpdir('test_wellformed') do |dir|
+      f = File.join(dir, 'a.xml')
+      File.write(f, '<hello>Dude!</hello>')
+      assert_predicate(
+        Xcop::Document.new(f), :wellformed?,
+        'Expected a sloppy but parseable XML file to be reported as well-formed'
+      )
+    end
+  end
+
   def test_fix_reports_malformed_when_not_wellformed
     Dir.mktmpdir('test_fix_malformed') do |dir|
       f = File.join(dir, 'broken.xml')


### PR DESCRIPTION
While checking, `Xcop::CLI#run` now asks the document whether it is well-formed XML before diffing it, and skips it when it is not. The block it yields to gets a status, `:good` or `:malformed`, so `bin/xcop` prints "is not a well-formed XML, skipping it" and the rake task marks the file with a yellow `?` instead of a green dot. `Xcop::Document#wellformed?`, which `--fix` has used since #173, became public for this.

Before this, `xcop foo.txt` on a plain text file dumped a diff of that text against an empty `<?xml version="1.0"?>` declaration and exited with 1, complaining about XML formatting in a file that holds no XML. The two paths disagreed about the same file: `--fix` left it alone while checking failed on it. Now they agree.

An empty file still fails as before, since Nokogiri parses it without a fatal error, and a directory argument is still filtered by extension, so this only changes what happens to files named explicitly on the command line.

Closes #175
